### PR TITLE
Fixing subtitle search for episode with series imdb id and adding few more fields in SubtitleInfo

### DIFF
--- a/src/main/java/com/github/wtekiela/opensub4j/impl/SearchOperation.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/impl/SearchOperation.java
@@ -61,6 +61,13 @@ class SearchOperation extends AbstractListOperation<SubtitleInfo> {
             videoProperties.put("tag", tag);
         } else if (imdbid != null && !imdbid.isEmpty()) {
             videoProperties.put("imdbid", imdbid);
+            //if imdb id is for a series
+            if (season != null && !season.isEmpty()) {
+                videoProperties.put("season", season);
+            }
+            if (episode != null && !episode.isEmpty()) {
+                videoProperties.put("episode", episode);
+            }
         } else if (query != null && !query.isEmpty()) {
             videoProperties.put("query", query);
             if (season != null && !season.isEmpty()) {

--- a/src/main/java/com/github/wtekiela/opensub4j/response/SubtitleInfo.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/response/SubtitleInfo.java
@@ -46,6 +46,15 @@ public class SubtitleInfo {
 
     @OpenSubtitlesApiSpec(fieldName = "SubEncoding")
     private String encoding;
+    
+    @OpenSubtitlesApiSpec(fieldName = "IDMovieImdb")
+    private String imdbId;
+    
+    @OpenSubtitlesApiSpec(fieldName = "SubSize")
+    private int subtitleSize;
+    
+    @OpenSubtitlesApiSpec(fieldName = "SubRating")
+    private double subtitleRating;
 
     public SubtitleInfo() {
     }
@@ -103,6 +112,18 @@ public class SubtitleInfo {
 
     public String getEncoding() {
         return encoding;
+    }
+    
+    public String getImdbId() {
+    	return imdbId;
+    }
+    
+    public int getSubtitleSize() {
+    	return subtitleSize;
+    }
+    
+    public double getSubtitleRating() {
+    	return subtitleRating;
     }
 
     @Override

--- a/src/test/java/com/github/wtekiela/opensub4j/impl/SearchOperationTest.java
+++ b/src/test/java/com/github/wtekiela/opensub4j/impl/SearchOperationTest.java
@@ -242,6 +242,65 @@ class SearchOperationTest {
         assertEquals(EPISODE, videoParams.get("episode"));
         assertEquals(4, videoParams.size());
     }
+    
+    @Test
+    void testImdbIdWithSeason() {
+
+        // given
+        String movieHash = "";
+        String movieByteSize = "";
+        String tag = "";
+        String imdbid = IMDBID;
+        String query = "";
+        String season = SEASON;
+        String episode = "";
+
+        SearchOperation objectUnderTest = new SearchOperation(
+            TOKEN, LANG, movieHash, movieByteSize, tag, imdbid, query, season, episode
+        );
+
+        // when
+        Object[] params = objectUnderTest.getParams();
+
+        // then
+        assertEquals(TOKEN, params[0]);
+        Object[] videoProperties = (Object[]) params[1];
+        Map<String, String> videoParams = (Map<String, String>) videoProperties[0];
+        assertEquals(LANG, videoParams.get("sublanguageid"));
+        assertEquals(IMDBID, videoParams.get("imdbid"));
+        assertEquals(SEASON, videoParams.get("season"));
+        assertEquals(3, videoParams.size());
+    }
+
+    @Test
+    void testImdbIdWithSeasonAndEpisode() {
+
+        // given
+        String movieHash = "";
+        String movieByteSize = "";
+        String tag = "";
+        String imdbid = IMDBID;
+        String query = "";
+        String season = SEASON;
+        String episode = EPISODE;
+
+        SearchOperation objectUnderTest = new SearchOperation(
+            TOKEN, LANG, movieHash, movieByteSize, tag, imdbid, query, season, episode
+        );
+
+        // when
+        Object[] params = objectUnderTest.getParams();
+
+        // then
+        assertEquals(TOKEN, params[0]);
+        Object[] videoProperties = (Object[]) params[1];
+        Map<String, String> videoParams = (Map<String, String>) videoProperties[0];
+        assertEquals(LANG, videoParams.get("sublanguageid"));
+        assertEquals(IMDBID, videoParams.get("imdbid"));
+        assertEquals(SEASON, videoParams.get("season"));
+        assertEquals(EPISODE, videoParams.get("episode"));
+        assertEquals(4, videoParams.size());
+    }
 
 
 }


### PR DESCRIPTION
I have added the below there fields in SubtitleInfo,

- imdbId: In case I search from a query or fetch episode subtitle from series imdb id I would like to know the imdb id of the content

- subtitleSize: Will help me to pick the largest file size subtitle as that is my requirement

- subtitleRating: Will help me evaluate the quality of the subtitle before I download them
