### PR TITLE
Enhancing login response with additional data

### DIFF
--- a/src/integTest/java/com/github/wtekiela/opensub4j/impl/OpenSubtitlesClientImplIntegTest.java
+++ b/src/integTest/java/com/github/wtekiela/opensub4j/impl/OpenSubtitlesClientImplIntegTest.java
@@ -8,6 +8,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.github.wtekiela.opensub4j.api.OpenSubtitlesClient;
 import com.github.wtekiela.opensub4j.response.ListResponse;
+import com.github.wtekiela.opensub4j.response.LoginResponse;
 import com.github.wtekiela.opensub4j.response.MovieInfo;
 import com.github.wtekiela.opensub4j.response.Response;
 import com.github.wtekiela.opensub4j.response.ResponseStatus;
@@ -113,14 +114,14 @@ class OpenSubtitlesClientImplIntegTest {
         // given
 
         // when
-        Response response = login();
+        LoginResponse response = login();
 
         // then
         assertTrue(objectUnderTest.isLoggedIn());
         assertEquals(ResponseStatus.OK, response.getStatus());
     }
 
-    private Response login() throws XmlRpcException {
+    private LoginResponse login() throws XmlRpcException {
         String username = System.getenv("OS_USER");
         if (username == null || username.isEmpty()) {
             username = DEFAULT_USERNAME;

--- a/src/main/java/com/github/wtekiela/opensub4j/impl/LogInOperation.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/impl/LogInOperation.java
@@ -12,9 +12,9 @@
  */
 package com.github.wtekiela.opensub4j.impl;
 
-import com.github.wtekiela.opensub4j.response.LoginToken;
+import com.github.wtekiela.opensub4j.response.LoginResponse;
 
-class LogInOperation extends AbstractOperation<LoginToken> {
+class LogInOperation extends AbstractOperation<LoginResponse> {
 
     private final String user;
     private final String pass;
@@ -39,8 +39,8 @@ class LogInOperation extends AbstractOperation<LoginToken> {
     }
 
     @Override
-    LoginToken getResponseObject() {
-        return new LoginToken();
+    LoginResponse getResponseObject() {
+        return new LoginResponse();
     }
 
 }

--- a/src/main/java/com/github/wtekiela/opensub4j/impl/OpenSubtitlesClientImpl.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/impl/OpenSubtitlesClientImpl.java
@@ -111,12 +111,12 @@ public class OpenSubtitlesClientImpl implements OpenSubtitlesClient {
     @Override
     public synchronized LoginResponse login(String user, String pass, String lang, String useragent) throws XmlRpcException {
         ensureNotLoggedIn();
-        LoginResponse loginResponse =
+        LoginResponse response =
             new LogInOperation(user, pass, lang, useragent).execute(xmlRpcClient, responseParser);
-        if (ResponseStatus.OK.equals(loginResponse.getStatus())) {
-            this.loginResponse = loginResponse;
+        if (ResponseStatus.OK.equals(response.getStatus())) {
+            this.loginResponse = response;
         }
-        return loginResponse;
+        return response;
     }
 
     @Override

--- a/src/main/java/com/github/wtekiela/opensub4j/impl/OpenSubtitlesClientImpl.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/impl/OpenSubtitlesClientImpl.java
@@ -109,7 +109,7 @@ public class OpenSubtitlesClientImpl implements OpenSubtitlesClient {
     }
 
     @Override
-    public synchronized Response login(String user, String pass, String lang, String useragent) throws XmlRpcException {
+    public synchronized LoginResponse login(String user, String pass, String lang, String useragent) throws XmlRpcException {
         ensureNotLoggedIn();
         LoginResponse loginResponse =
             new LogInOperation(user, pass, lang, useragent).execute(xmlRpcClient, responseParser);

--- a/src/main/java/com/github/wtekiela/opensub4j/response/LoginResponse.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/response/LoginResponse.java
@@ -24,6 +24,13 @@ public class LoginResponse extends Response {
         return token;
     }
 
+    @OpenSubtitlesApiSpec(fieldName = "data")
+    private UserInfo userInfo;
+
+    public UserInfo getUserInfo() {
+        return userInfo;
+    }
+
     @Override
     public int hashCode() {
         return Objects.hash(token);

--- a/src/main/java/com/github/wtekiela/opensub4j/response/LoginResponse.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/response/LoginResponse.java
@@ -15,7 +15,7 @@ package com.github.wtekiela.opensub4j.response;
 import java.util.Objects;
 import java.util.StringJoiner;
 
-public class LoginToken extends Response {
+public class LoginResponse extends Response {
 
     @OpenSubtitlesApiSpec(fieldName = "token")
     private String token;
@@ -37,13 +37,13 @@ public class LoginToken extends Response {
         if (o == null || getClass() != o.getClass()) {
             return false;
         }
-        LoginToken that = (LoginToken) o;
+        LoginResponse that = (LoginResponse) o;
         return Objects.equals(token, that.token);
     }
 
     @Override
     public String toString() {
-        return new StringJoiner(", ", LoginToken.class.getSimpleName() + "[", "]")
+        return new StringJoiner(", ", LoginResponse.class.getSimpleName() + "[", "]")
             .add("token='" + token + "'")
             .toString();
     }

--- a/src/main/java/com/github/wtekiela/opensub4j/response/LoginResponse.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/response/LoginResponse.java
@@ -52,6 +52,7 @@ public class LoginResponse extends Response {
     public String toString() {
         return new StringJoiner(", ", LoginResponse.class.getSimpleName() + "[", "]")
             .add("token='" + token + "'")
+            .add("userInfo=" + userInfo)
             .toString();
     }
 }

--- a/src/main/java/com/github/wtekiela/opensub4j/response/UserInfo.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/response/UserInfo.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright (c) 2020 Wojciech Tekiela
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package com.github.wtekiela.opensub4j.response;
+
+public class UserInfo {
+
+    @OpenSubtitlesApiSpec(fieldName = "UserRank")
+    private String userRank;
+
+    @OpenSubtitlesApiSpec(fieldName = "UserNickName")
+    private String userNickName;
+
+    @OpenSubtitlesApiSpec(fieldName = "UploadCnt")
+    private int uploadCount;
+
+    @OpenSubtitlesApiSpec(fieldName = "DownloadCnt")
+    private int downloadCount;
+
+    @OpenSubtitlesApiSpec(fieldName = "IsVIP")
+    private boolean isVip;
+
+    @OpenSubtitlesApiSpec(fieldName = "UserWebLanguage")
+    private String userWebLanguage;
+
+    @OpenSubtitlesApiSpec(fieldName = "UserPreferedLanguages")
+    private String userPreferedLanguages;
+
+    @OpenSubtitlesApiSpec(fieldName = "IDUser")
+    private String userId;
+
+    public String getUserRank() {
+        return userRank;
+    }
+
+    public String getUserNickName() {
+        return userNickName;
+    }
+
+    public int getUploadCount() {
+        return uploadCount;
+    }
+
+    public int getDownloadCount() {
+        return downloadCount;
+    }
+
+    public boolean isVip() {
+        return isVip;
+    }
+
+    public String getUserWebLanguage() {
+        return userWebLanguage;
+    }
+
+    public String getUserPreferedLanguages() {
+        return userPreferedLanguages;
+    }
+
+    public String getUserId() {
+        return userId;
+    }
+}

--- a/src/main/java/com/github/wtekiela/opensub4j/response/UserInfo.java
+++ b/src/main/java/com/github/wtekiela/opensub4j/response/UserInfo.java
@@ -12,6 +12,9 @@
  */
 package com.github.wtekiela.opensub4j.response;
 
+import java.util.Objects;
+import java.util.StringJoiner;
+
 public class UserInfo {
 
     @OpenSubtitlesApiSpec(fieldName = "UserRank")
@@ -68,5 +71,44 @@ public class UserInfo {
 
     public String getUserId() {
         return userId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        UserInfo userInfo = (UserInfo) o;
+        return uploadCount == userInfo.uploadCount && downloadCount == userInfo.downloadCount &&
+            isVip == userInfo.isVip &&
+            Objects.equals(userRank, userInfo.userRank) &&
+            Objects.equals(userNickName, userInfo.userNickName) &&
+            Objects.equals(userWebLanguage, userInfo.userWebLanguage) &&
+            Objects.equals(userPreferedLanguages, userInfo.userPreferedLanguages) &&
+            Objects.equals(userId, userInfo.userId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects
+            .hash(userRank, userNickName, uploadCount, downloadCount, isVip, userWebLanguage, userPreferedLanguages,
+                userId);
+    }
+
+    @Override
+    public String toString() {
+        return new StringJoiner(", ", UserInfo.class.getSimpleName() + "[", "]")
+            .add("userRank='" + userRank + "'")
+            .add("userNickName='" + userNickName + "'")
+            .add("uploadCount=" + uploadCount)
+            .add("downloadCount=" + downloadCount)
+            .add("isVip=" + isVip)
+            .add("userWebLanguage='" + userWebLanguage + "'")
+            .add("userPreferedLanguages='" + userPreferedLanguages + "'")
+            .add("userId='" + userId + "'")
+            .toString();
     }
 }

--- a/src/test/java/com/github/wtekiela/opensub4j/impl/ResponseParserTest.java
+++ b/src/test/java/com/github/wtekiela/opensub4j/impl/ResponseParserTest.java
@@ -1,6 +1,7 @@
 package com.github.wtekiela.opensub4j.impl;
 
 import com.github.wtekiela.opensub4j.response.ListResponse;
+import com.github.wtekiela.opensub4j.response.LoginResponse;
 import com.github.wtekiela.opensub4j.response.SubtitleFile;
 import java.util.HashMap;
 import java.util.Map;
@@ -74,5 +75,27 @@ class ResponseParserTest {
         Assertions.assertTrue(result.getData().isPresent());
         SubtitleFile subtitleFile = result.getData().get().get(0);
         Assertions.assertEquals(TEST_SUBTITE_FILE_ID, subtitleFile.getId());
+    }
+
+    @Test
+    void testBindNestedData() {
+        // given
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("UserRank", "sub leecher");
+        entry.put("UserNickName", "wteq");
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("seconds", 0.005d);
+        response.put("data", entry);
+        response.put("status", "200 OK");
+
+        // when
+        LoginResponse result =
+            objectUnderTest.bind(new LoginResponse(), response);
+
+        // then
+        Assertions.assertEquals(200, result.getStatus().getCode());
+        Assertions.assertEquals("wteq", result.getUserInfo().getUserNickName());
+        Assertions.assertEquals("sub leecher", result.getUserInfo().getUserRank());
     }
 }


### PR DESCRIPTION
Login response looks like this:
```
{seconds=0.048, data={UserRank=##, UserNickName=##, UploadCnt=xxx, DownloadCnt=xxx, IsVIP=0, UserWebLanguage=en, IDUser=xxxxx, UserPreferedLanguages=eng}, token=-abcdefgh1234, status=200 OK}
```

This PR aims to augment `LoginResponse` object with `UserInfo` data visible as part of nested `data` field in the response. This includes enhancing `ResponseParser` to support nested objects.