### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     token:
       secure: HIyfkrDQQwHRgvFLeCzrnPmnJny05RXNtUYZtm6/48TYkeRju/fMMzQE0mY0vOVyJVRsssyQHS+f/vJX/RF3pSHAlbUTQ3Pl90/Q/TfZdWzGnPZh28avoa+HGBATV0tiKdvYgtDI67ywarEZZdfTXrzT/zEkc3g7sz1vd8MfM/s=
 git:
-  depth: false
+  depth: 3
 install:
 - travis_retry ./gradlew clean assemble -x signArchives --info
 script:


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.