### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,14 @@ addons:
 git:
   depth: false
 install:
-- travis_retry ./gradlew clean assemble -x signArchives --info
+- ./gradlew clean assemble -x signArchives --info
 script:
-- travis_retry ./gradlew check sonarqube --info
+- ./gradlew check sonarqube --info
 env:
   global:
   - secure: IgPA92ioawuSMTZ4DPvghZRaATl4ZW/oeJinqqlDxcJ9wnaKlJjb50mrKrWXs+JMI74Z//En7dwDTPDu69D4IUKiQfHJ70kCv3DVDX/TCnGoEhkOgVSVicpVJtHxTyuXKOPK3ASZwynA989jPku4b3T2uO4VYMuioD1sWMrWJBA=
   - secure: Kg6mpdrNhhQUjIQnTGVagVT8MMG6lvIeGL0ZKQE+gUvOqCz5EI//aPo48RnhZptSQPKHDJXEmtX4eDM61btyrhuF2YKsk9oH5LDhtOP95LQHsjZmspzoRZSOEq6nMBIEsQjmAkK9g3kLFn8bcRmrKhgVvZhcrVQI6VZarPe46Gs=
+cache:
+  directories:
+  - $HOME/.gradle/caches/
+  - $HOME/.gradle/wrapper/


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

[Caching Dependencies and Directories](https://docs.travis-ci.com/user/caching/) Travis CI can cache content that does not often change, to speed up the build process.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
